### PR TITLE
upgrade to quarto version 1.4.499 and add lightbox

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v1.4.449
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: 1.4.449
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - lightbox
 
 jobs:
   build-deploy:
@@ -15,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@v1.4.449
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2

--- a/chapters/installation-setup.qmd
+++ b/chapters/installation-setup.qmd
@@ -67,7 +67,20 @@ Once the installer is downloaded, double-click it to run the installation.
 During the installation process, you'll be presented with various options and settings.
 We recommend to leave all settings to their standard configuration, unless you have a specific need to e.g. change the installation destination.
 
-![](../static/git_bash_inst_2.png){width="200"} ![](../static/git_bash_inst_3.png){width="200"}![](../static/git_bash_inst_4.png){width="200"} ![](../static/git_bash_inst_5.png){width="200"} ![](../static/git_bash_inst_6.png){width="200"} ![](../static/git_bash_inst_7.png){width="200"} ![](../static/git_bash_inst_8.png){width="200"} ![](../static/git_bash_inst_9.png){width="200"} ![](../static/git_bash_inst_10.png){width="200"} ![](../static/git_bash_inst_11.png){width="200"} ![](../static/git_bash_inst_12.png){width="200"} ![](../static/git_bash_inst_13.png){width="200"}
+**Note:** Click on one of the images to see them in gallery mode!
+
+![](../static/git_bash_inst_2.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_3.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_4.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_5.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_6.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_7.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_8.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_9.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_10.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_11.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_12.png){.lightbox group="git-bash" width="200"}
+![](../static/git_bash_inst_13.png){.lightbox group="git-bash" width="200"}
 
 Once you have finished selecting your preference, click the install button to begin the installation process.
 


### PR DESCRIPTION
hi @konradpa,

this PR adds the [lightbox](https://quarto.org/docs/prerelease/1.4/lightbox.html) image viewing option.
this requires to upgrade to quarto version 1.4.499 though, which is a pre-release version.

issues that I've discovered so far:

- hamburger menu does not work on mobile
- the "back" option at the end of the chapter looks weird (see below)

![image](https://github.com/lnnrtwttkhn/version-control-book/assets/42233065/4926aacf-6fec-4903-991e-e3da6957eec4)

likely those issues will be fixed in future releases (and maybe we need to change something in our settings) but I am currently unsure whether we should merge this "only" to have access to the lightbox function.