### PR TITLE
externalize learning objectives + exercises, add separate sections #92

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -26,6 +26,7 @@ book:
   chapters:
     - index.qmd
     - contents.qmd
+    - misc/objectives.qmd
     - chapters/intro-version-control.qmd
     - chapters/command-line.qmd
     - chapters/installation.qmd
@@ -41,6 +42,7 @@ book:
     - chapters/gui.qmd
     - chapters/intermediate-commands.qmd
     - chapters/rewriting-history.qmd
+    - misc/exercises.qmd
     - misc/cheatsheet.qmd
     - misc/references.qmd
     - misc/acknowledgements.qmd

--- a/chapters/branches.qmd
+++ b/chapters/branches.qmd
@@ -31,15 +31,11 @@ about:
 
 <h5>Learning Objectives</h5>
 
-:bulb: Knowing purpose and benefits of using branches in Git<br>
-:bulb: Creating and switching between branches<br>
-:bulb: Merging branches and resolving conflicts
+{{< include ../objectives/_objectives-branches.qmd >}}
 
 <h5>Exercises</h5>
 
-:memo: Create a new branch called `feature/newrecipe` <br>
-:memo: Add a new recipe to your recipe text file <br>
-:memo: Merge this branch with your `main` branch and delete the `feature` branch afterwards 
+{{< include ../exercises/_exercises-branches.qmd >}}
 
 :::
 

--- a/exercises/_exercises-branches.qmd
+++ b/exercises/_exercises-branches.qmd
@@ -1,0 +1,3 @@
+:memo: Create a new branch called `feature/newrecipe` <br>
+:memo: Add a new recipe to your recipe text file <br>
+:memo: Merge this branch with your `main` branch and delete the `feature` branch afterwards

--- a/misc/exercises.qmd
+++ b/misc/exercises.qmd
@@ -1,0 +1,10 @@
+---
+author: ""
+title-block-style: none
+---
+
+# Exercises {.unnumbered}
+
+## Branches
+
+{{< include ../exercises/_exercises-branches.qmd >}}

--- a/misc/objectives.qmd
+++ b/misc/objectives.qmd
@@ -1,0 +1,10 @@
+---
+author: ""
+title-block-style: none
+---
+
+# Learning Objectives {.unnumbered}
+
+## Branches
+
+{{< include ../objectives/_objectives-branches.qmd >}}

--- a/objectives/_objectives-branches.qmd
+++ b/objectives/_objectives-branches.qmd
@@ -1,0 +1,3 @@
+:bulb: Knowing purpose and benefits of using branches in Git<br>
+:bulb: Creating and switching between branches<br>
+:bulb: Merging branches and resolving conflicts


### PR DESCRIPTION
- move learning objectives and exercises to separate .qmd files in /objectives and /exercises, respectively
- reference these .qmd files as "includes" in chapter, see https://quarto.org/docs/authoring/includes.html
- create new pages for learning objectives and exercises that are supposed to list all objectives and exercises, similar to cheatsheet  page