### PR TITLE
add .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,32 @@
+{
+    "upload_type": "publication",
+    "publication_type": "book",
+    "publication_date": "YYYY-MM-DD",
+    "title": "Version Control Book",
+    "creators": [
+        {
+            "name": "Wittkuhn, Lennart",
+            "affiliation": "University of Hamburg, Institute of Psychology",
+            "orcid": "0000-0003-2966-6888"
+        },
+        {
+            "name": "Pagenstedt, Konrad",
+            "affiliation": "University of Hamburg, Institute of Psychology",
+            "orcid": "Creator ORCID (optional)"
+        },
+        {
+            "name": "Schuck, Nicolas W.",
+            "affiliation": "University of Hamburg, Institute of Psychology",
+            "orcid": "0000-0002-0150-8776"
+        }
+    ],
+    "description": "The Version Control Book is a comprehensive educational resource for version control of code and data with Git for scientists.",
+    "access_right": "open",
+    "license": "CC-BY-SA-4.0",
+    "keywords": [
+        "version control",
+        "git",
+        "github"
+    ],
+    "language": "eng"
+}


### PR DESCRIPTION
the `.zenodo.json` file provides metadata for a release on https://zenodo.org/

metadata information can be found here: https://developers.zenodo.org/#representation

@konradpa, do you have an ORCiD or are considering to create one? more information here: https://orcid.org/ and we can also chat about this.

things to consider:

- [ ] add any additional metadata? see https://developers.zenodo.org/#representation
- [ ] license okay?
- [ ] description okay?
- [ ] add additional keywords?
- [ ] how can we credit ddlitlab etc.?