### PR TITLE
fix quotation mark issue in tags and releases section of Cheatsheet.json

### DIFF
--- a/cheatsheet.json
+++ b/cheatsheet.json
@@ -88,7 +88,7 @@
     "git tag": "Lists all tags",
     "git tag v1.0": "Creates a tag on the basis of your current commit named `v1.0`",
     "git tag v1.1 <commit-hash>": "Creates a tag on the basis of a specific commit hash named `v1.1`",
-    "git tag -a v1.0 -m Release version 1.0": "Creates an annotated tag on the basis of your current commit hash named `v1.0` with the tagging message `Release version 1.0`",
+    "git tag -a v1.0 -m 'Release version 1.0'": "Creates an annotated tag on the basis of your current commit hash named `v1.0` with the tagging message `Release version 1.0`",
     "git push origin <tag-name>": "Pushes a specific tag to remote",
     "git push origin --tags": "Pushes all created tags to remote",
     "git fetch --tags": "Fetches all created tags from remote",

--- a/cheatsheet.json
+++ b/cheatsheet.json
@@ -88,7 +88,7 @@
     "git tag": "Lists all tags",
     "git tag v1.0": "Creates a tag on the basis of your current commit named `v1.0`",
     "git tag v1.1 <commit-hash>": "Creates a tag on the basis of a specific commit hash named `v1.1`",
-    "git tag -a v1.0 -m 'Release version 1.0'": "Creates an annotated tag on the basis of your current commit hash named `v1.0` with the tagging message `Release version 1.0`",
+    'git tag -a v1.0 -m "Release version 1.0"': "Creates an annotated tag on the basis of your current commit hash named `v1.0` with the tagging message `Release version 1.0`",
     "git push origin <tag-name>": "Pushes a specific tag to remote",
     "git push origin --tags": "Pushes all created tags to remote",
     "git fetch --tags": "Fetches all created tags from remote",


### PR DESCRIPTION
Resolves #199 

In the tags cheatsheet, updates the create tag command:
adds double quotation marks around the command message and changes double quotation marks around whole command to single quotation marks