### PR TITLE
Add info about usernames on configuration levels

### DIFF
--- a/chapters/intro-version-control.qmd
+++ b/chapters/intro-version-control.qmd
@@ -91,7 +91,7 @@ However, remember that your number one collaborator is yourself from six months 
 
 Imagine you were on a very long vacation (who would not like to imagine that!) and you would come back to a project folder as illustrated in @fig-phd-comic-story-told-in-file-names.
 Would you know which file to continue working with?
-Would you know how the different files related to each other?
+Would you know how the different files are related to each other?
 How could someone else start working with this project or how would you start working with this if you would get such a project folder from someone else?
 It is very difficult to understand how to work with this project and you will likely spend a lot of time figuring out what all the different files are, what they mean and why they are titled in such a way.
 

--- a/chapters/setup.qmd
+++ b/chapters/setup.qmd
@@ -84,7 +84,7 @@ Your username will be attached to the changes you track with Git, so **choose so
 After all, one main purpose of Git is to be able to track of *who* made which changes and when.
 This can help a lot in the future when you need to figure out who to talk to about a particular change.
 Your username can be your **real name**, your **GitHub username**, or something informative about you.
-You can change your username and email adress for different projects by setting them up on the respective configuration level (for details, see @tip-config-levels).
+You can change your username and email address for different projects by setting them up on the respective configuration level (for details, see @tip-config-levels).
 This can be useful if you have a work related and a private GitHub account or work for several companies at the same time.
 :::
 

--- a/chapters/setup.qmd
+++ b/chapters/setup.qmd
@@ -84,6 +84,8 @@ Your username will be attached to the changes you track with Git, so **choose so
 After all, one main purpose of Git is to be able to track of *who* made which changes and when.
 This can help a lot in the future when you need to figure out who to talk to about a particular change.
 Your username can be your **real name**, your **GitHub username**, or something informative about you.
+You can change your username and email adress for different projects by setting them up on the respective configuration level (for details, see @tip-config-levels).
+This can be useful if you have a work related and a private GitHub account or work for several companies at the same time.
 :::
 
 ::: {.callout-caution title="Important: Consider your privacy preferences!"}


### PR DESCRIPTION
Added info that one can use a different username for different projects and referenced tip about configuration levels, see #286. Also fixed a typo, fixes #254 