### PR TITLE
Add more info on choice of GUI

### DIFF
--- a/chapters/gui.qmd
+++ b/chapters/gui.qmd
@@ -33,6 +33,17 @@ There is a wide variety of Git GUIs available, and each of them offers its own s
 In this section, we will focus on [GitHub Desktop](https://desktop.github.com) and [GitKraken](https://www.gitkraken.com), although many more options exist.
 For a more comprehensive overview, you can explore the [official Git website](https://git-scm.com/downloads/guis/).
 
+::: {.callout-tip title="How do GitHub Desktop and GitKraken differ and which should I choose?" collapse="true"}
+Whilst it is possible to switch between different GUIs or use multiple at the same time, you might just want to focus on one.
+If that's the case, here are some considerations regarding GitHub Desktop and GitKraken that could help you decide which one is a better fit for you and your projects.  
+First of all, for Linux users, GitHub Desktop simply doesn't offer an official version. 
+Another factor can be cost, as GitHub Desktop is free to use, while GitKraken is only free for students or during a 7-day trial period. 
+Overall, GitHub Desktop offers a simpler interface, making it more intuitive for beginners.
+However, this simplicity comes at the cost of having fewer features compared to GitKraken, which could be limiting if you want to perform more complex tasks.
+GitHub Desktop is very well integrated with GitHub, but can be restricting if you want to work with repositories hosted on other platforms. 
+In that case, GitKraken offers better support for a wider range of Git hosting services.
+:::
+
 ### {{< fa brands github >}} GitHub Desktop
 
 #### Download
@@ -142,7 +153,7 @@ The branches tab in the Git pane displays a list of available branches, making i
 ![Screenshot of RStudio. Showing an example repository.](../static/rstudio-panels.png){#fig-Rstudio_window}
 
 Clicking "Commit" will open up a window, where you see your changes marked with colors.
-You also easily write commit message and have the option to amend your last command.
+You can also easily write a commit message and have the option to amend your last command.
 It is also possible to stage specific lines.
 
 ![Screenshot of Rstudio. Showing an example commit.](../static/rstudio-commit.png){#fig-Rstudio_commit}


### PR DESCRIPTION
Added a callout box to add central information on some differences between GitHub Desktop and GitKraken. Fixes #297 