### PR TITLE
Add section on aliases and reference to coderefinery

### DIFF
--- a/chapters/branches.qmd
+++ b/chapters/branches.qmd
@@ -764,6 +764,13 @@ In this example, the graph shows that the `feature` branch has diverged from the
 The asterisk (`*`) represents commits, while the lines (`|`) show the relationships between these commits and branches.
 The `\` indicates that two branches (in this case, `main` and `feature`) have joined after being separate.
 
+Creating an [alias](setup.qmd#aliases) for this visualization command can be a good idea, as it will likely be used often and it's easy to forget to add some flags.
+After running the code below, you can simply use `git graph` instead of `git log --oneline --graph --all --decorate` for the same result ^[This alias was adopted from [coderefinery 2024](https://coderefinery.github.io/git-intro/aliases).].
+
+```{zsh, filename="Code"}
+git config --global alias.graph "log --oneline --graph --all --decorate"
+```
+
 ## Acknowledgements & further reading
 
 We would like to express our gratitude to the following resources, which have been essential in shaping this chapter.
@@ -775,7 +782,7 @@ We recommend these references for further reading:
 #| message: false
 #| warning: false
 #| output: asis
-bibtexkeys = c("GitHub2023", "chacon2014", "community2022", "amin2023")
+bibtexkeys = c("GitHub2023", "chacon2014", "community2022", "amin2023", "coderefinery2024")
 knitr::kable(ref_table(bibtexkeys), format = "markdown")
 ```
 

--- a/chapters/branches.qmd
+++ b/chapters/branches.qmd
@@ -764,8 +764,10 @@ In this example, the graph shows that the `feature` branch has diverged from the
 The asterisk (`*`) represents commits, while the lines (`|`) show the relationships between these commits and branches.
 The `\` indicates that two branches (in this case, `main` and `feature`) have joined after being separate.
 
-Creating an [alias](setup.qmd#aliases) for this visualization command can be a good idea, as it will likely be used often and it's easy to forget to add some flags.
-After running the code below, you can simply use `git graph` instead of `git log --oneline --graph --all --decorate` for the same result ^[This alias was adopted from [coderefinery 2024](https://coderefinery.github.io/git-intro/aliases).].
+#### Creating an alias
+
+Creating an [alias](setup.qmd#aliases) for this visualization command can be a good idea, as it will likely be used often, and it's easy to forget to add some flags.
+After running the command below, you can simply use `git graph` instead of `git log --oneline --graph --all --decorate` for the same result ^[This alias was adopted from [CodeRefinery 2024](https://coderefinery.github.io/git-intro/aliases).].
 
 ```{zsh, filename="Code"}
 git config --global alias.graph "log --oneline --graph --all --decorate"

--- a/chapters/setup.qmd
+++ b/chapters/setup.qmd
@@ -380,6 +380,21 @@ This command will result in an output similar to this:
 
 You can manually edit the `.gitconfig` file to customize your Git environment, but it's often more convenient to use Git commands like `git config` to manage these settings.
 
+## Aliases
+
+Aliases are customizable shortcuts for Git commands.
+When having to retype the same commands over and over again, aliases can help save time, nerves and avoid typos in more complex commands.
+Any name can be chosen for an alias.
+They can be set on different configuration levels and thus either stay the same over all your repositories or change between them.^[:bulb: See Tip 4.1 about configuration levels (details [here](setup.qmd#tip-config-levels))]
+Aliases are stored in the `.gitconfig` file and can be changed directly in there or using `git config`.
+For example, to set the command `git ci` as an alias for `git commit` on the global configuration level, use the following:
+
+```{bash filename="Code"}
+git config --global alias.ci "commit"
+```
+
+Both `git ci` and `git commit` can now be used interchangeably and if needed, more aliases can even be set for the same command.
+
 ## Helpful guardrails
 
 Especially if you are new to Git (but not only then!), you might be worried that something will go terribly wrong, that you will lose files beyond recovery, or that you will break your computer.
@@ -441,7 +456,7 @@ We recommend these references for further reading:
 #| message: false
 #| warning: false
 #| output: asis
-bibtexkeys = c("bryan2023", "capes2023", "chacon2014", "koziar2023")
+bibtexkeys = c("bryan2023", "capes2023", "chacon2014", "coderefinery2024", "koziar2023")
 knitr::kable(ref_table(bibtexkeys), format = "markdown")
 ```
 

--- a/chapters/setup.qmd
+++ b/chapters/setup.qmd
@@ -396,6 +396,8 @@ git config --global alias.ci "commit"
 
 Both `git ci` and `git commit` can now be used interchangeably, and if needed, more aliases can be set, even for the same command.
 
+Check out the [list of aliases](https://coderefinery.github.io/git-intro/aliases/#list-of-aliases-the-instructors-use) used by instructors from @coderefinery2024 for inspiration on what kinds of aliases you could set in your Git configuration.
+
 ## Helpful guardrails
 
 Especially if you are new to Git (but not only then!), you might be worried that something will go terribly wrong, that you will lose files beyond recovery, or that you will break your computer.

--- a/chapters/setup.qmd
+++ b/chapters/setup.qmd
@@ -382,18 +382,19 @@ You can manually edit the `.gitconfig` file to customize your Git environment, b
 
 ## Aliases
 
-Aliases are customizable shortcuts for Git commands.
-When having to retype the same commands over and over again, aliases can help save time, nerves and avoid typos in more complex commands.
+Aliases are **customizable shortcuts for Git commands**.
+When you have to retype the same commands over and over again, aliases can help save time, reduce frustration, and avoid typos in more complex commands.
 Any name can be chosen for an alias.
-They can be set on different configuration levels and thus either stay the same over all your repositories or change between them.^[:bulb: See Tip 4.1 about configuration levels (details [here](setup.qmd#tip-config-levels))]
-Aliases are stored in the `.gitconfig` file and can be changed directly in there or using `git config`.
-For example, to set the command `git ci` as an alias for `git commit` on the global configuration level, use the following:
+They can be set at different configuration levels and thus either remain the same across all your repositories or vary between them. ^[:bulb: See Tip 4.1 about configuration levels (details [here](setup.qmd#tip-config-levels))]
+Aliases are stored in the `.gitconfig` file and can be changed directly there or by using `git config`.
+
+For example, to set the command `git ci` as an alias for `git commit` at the global configuration level, use the following:
 
 ```{bash filename="Code"}
 git config --global alias.ci "commit"
 ```
 
-Both `git ci` and `git commit` can now be used interchangeably and if needed, more aliases can even be set for the same command.
+Both `git ci` and `git commit` can now be used interchangeably, and if needed, more aliases can be set, even for the same command.
 
 ## Helpful guardrails
 

--- a/references.bib
+++ b/references.bib
@@ -206,6 +206,15 @@
   note = {License: \href{https://creativecommons.org/licenses/by-nc/4.0/}{CC BY-NC 4.0}. Source: \url{https://github.com/coderefinery/github-without-command-line/tree/master}. Website: \url{https://coderefinery.github.io/github-without-command-line/}}
 }
 
+@book{coderefinery2024,
+  author = {coderefinery},
+  title = {Introduction to Version Control with Git. Aliases and Configuration},
+  year = {2024},
+  publisher = {coderefinery},
+  url = {https://coderefinery.github.io/git-intro/aliases},
+  note = {License: \href{https://creativecommons.org/licenses/by/4.0/}{CC BY 4.0}. Source: \url{https://github.com/coderefinery/git-intro}. Website: \url{https://coderefinery.github.io/git-intro/aliases}}
+}
+
 @online{amin2023,
   author = {Amin, Abhay},
   title = {Naming conventions for Git Branches — a Cheatsheet},

--- a/references.bib
+++ b/references.bib
@@ -207,7 +207,7 @@
 }
 
 @book{coderefinery2024,
-  author = {coderefinery},
+  author = {{CodeRefinery}},
   title = {Introduction to Version Control with Git. Aliases and Configuration},
   year = {2024},
   publisher = {coderefinery},


### PR DESCRIPTION
Added section on aliases in setup chapter and referenced https://coderefinery.github.io/git-intro/aliases/#aliases.
Partially deals with #270 but still misses further suggestions on useful aliases in later chapters.

Closes #270 