### PR TITLE
corrected typo in remotes-intro 8.6

### DIFF
--- a/chapters/remotes-intro.qmd
+++ b/chapters/remotes-intro.qmd
@@ -634,7 +634,7 @@ It tells Git to remember the remote branch to which your local branch should be 
 
 ::: {.callout-note title="The authenticity of host can't be established." collapse="false"}
 
-**TL;DR**: Enter `yet` and hit {{< kbd Enter >}}.
+**TL;DR**: Enter `yes` and hit {{< kbd Enter >}}.
 
 ---
 
@@ -649,7 +649,7 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])?
 
 This message indicates that your system is trying to connect to a remote server (in this case, GitHub) over SSH for the first time, but it doesn't yet trust the server's identity.
 
-If you are trusting the server's identity, enter `yet` and hit {{< kbd Enter >}}.
+If you are trusting the server's identity, enter `yes` and hit {{< kbd Enter >}}.
 This will result in the following message:
 
 ```{markdown filename="Output"}


### PR DESCRIPTION
I corrected the typo in chapter remotes 8.6. I changed it in two places from "yet" to "yes".

Fixes #323 