### PR TITLE
Add comment on the differences between shells on autocompletion

### DIFF
--- a/chapters/command-line.qmd
+++ b/chapters/command-line.qmd
@@ -507,9 +507,9 @@ In this section, we provide some tips and tricks to help you become more efficie
 ### Autocompletion
 
 ::: {.callout-warning title="Autocompletion options depend on your shell!"}
-Unfortunately this feature is not available in all basic shell versions.
+Unfortunately this feature is not available in all basic Shell versions.
 In Zsh and Powershell the autocompletion feature described here is available by default.
-In Bash, modifications are needed the get the same effect.
+In Bash, extensions have to be installed to get the same effect.
 :::
 
 While using the command line in Zsh or Powershell, instead of typing out the full command or path, you can press the {{< kbd ⇥ >}} (`Tab`) key to automatically complete the rest of the command.
@@ -535,9 +535,9 @@ $ cd ~/Do
 Documents/  Downloads/
 ```
 
-Similarly, in Bash, when pressing {{< kbd ⇥ Tab >}}  twice, it will return a list of the possible options, but won't cycle through them.
+Similarly, in Bash, when pressing {{< kbd ⇥ Tab >}} twice, it will return a list of the possible options, but won't cycle through them.
 
-For Zsh and Powershell, auto-completion also works for system commands. 
+For Zsh and Powershell, autocompletion also works for system commands. 
 For example, typing `ls` (you will find out more about this command [below](#list-files-and-folders)) and pressing {{< kbd ⇥ Tab >}} might complete it to `ls -l` or `ls -a`.
 Auto-completion also works for the Git commands that will be introduced in the following chapters of this book.
 You can also cycle *backwards* through autocompleted options by holding {{< kbd Shift >}} (`Shift`), then pressing {{< kbd ⇥ Tab >}}.

--- a/chapters/command-line.qmd
+++ b/chapters/command-line.qmd
@@ -506,7 +506,13 @@ In this section, we provide some tips and tricks to help you become more efficie
 
 ### Autocompletion
 
-While using the command line, instead of typing out the full command or path, you can press the {{< kbd ⇥ >}} (`Tab`) key to automatically complete the rest of the command.
+::: {.callout-warning title="Autocompletion options depend on your shell!"}
+Unfortunately this feature is not available in all basic shell versions.
+In Zsh and Powershell the autocompletion feature described here is available by default.
+In Bash, modifications are needed the get the same effect.
+:::
+
+While using the command line in Zsh or Powershell, instead of typing out the full command or path, you can press the {{< kbd ⇥ >}} (`Tab`) key to automatically complete the rest of the command.
 Begin typing a command or the initial letters of a file or directory, for example:
 
 ```{zsh filename="Code"}
@@ -529,7 +535,9 @@ $ cd ~/Do
 Documents/  Downloads/
 ```
 
-Auto-completion also works for system commands. 
+Similarly, in Bash, when pressing {{< kbd ⇥ Tab >}}  twice, it will return a list of the possible options, but won't cycle through them.
+
+For Zsh and Powershell, auto-completion also works for system commands. 
 For example, typing `ls` (you will find out more about this command [below](#list-files-and-folders)) and pressing {{< kbd ⇥ Tab >}} might complete it to `ls -l` or `ls -a`.
 Auto-completion also works for the Git commands that will be introduced in the following chapters of this book.
 You can also cycle *backwards* through autocompleted options by holding {{< kbd Shift >}} (`Shift`), then pressing {{< kbd ⇥ Tab >}}.


### PR DESCRIPTION
Added info on the differences between shells when using the tab key to autocomplete commands or cycle through options.

Appearently it's possible to install a sort of extentsion to get the same function in Bash, if wanted @lnnrtwttkhn, I could also add an explanation for this. As of now, I only mentioned it.
Otherwise, this fixes #327 
