### PR TITLE
Added command line output from generating SSH key

### DIFF
--- a/chapters/remotes-intro.qmd
+++ b/chapters/remotes-intro.qmd
@@ -217,6 +217,32 @@ To avoid typing the passphrase each time you connect, you can securely store it 
 For more details, see the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/working-with-ssh-key-passphrases).
 :::
 
+After (not) having entered a passphrase, your command line output should look similar to this: 
+
+```{zsh filename="Output"}
+Generating public/private ed25519 key pair.
+Enter file in which to save the key (/Users/user/.ssh/id_ed25519): 
+Created directory '/Users/user/.ssh'.
+Enter passphrase (empty for no passphrase): 
+Enter same passphrase again: 
+Your identification has been saved in /Users/user/.ssh/id_ed25519
+Your public key has been saved in /Users/user.ssh/id_ed25519.pub
+The key fingerprint is:
+SHA256: A2C4D8E9F9B3B2A4157C8D9E1FBB4D567543F2C9C4E6A3D422D8F7A1B3E5C6D0 user@email.com
+The key's randomart image is:
++--[ED25519 256]--+
+|               . |
+|              +  |
+|             Eo. |
+|    .         =+.|
+|   . .. S    = =o|
+|. . ...+ .  . B +|
+|.+ = .+ *  . +.*o|
+|..=..+.= ..   Bo=|
+| .o.o..   ..  .++|
++----[SHA256]-----+
+```
+
 #### Copying the public SSH key to your clipboard
 
 Now copy the SSH public key to your clipboard.

--- a/chapters/remotes-intro.qmd
+++ b/chapters/remotes-intro.qmd
@@ -219,12 +219,7 @@ For more details, see the [GitHub documentation](https://docs.github.com/en/auth
 
 After (not) having entered a passphrase, your command line output should look similar to this: 
 
-```{zsh filename="Output"}
-Generating public/private ed25519 key pair.
-Enter file in which to save the key (/Users/user/.ssh/id_ed25519): 
-Created directory '/Users/user/.ssh'.
-Enter passphrase (empty for no passphrase): 
-Enter same passphrase again: 
+```{markdown filename="Output"}
 Your identification has been saved in /Users/user/.ssh/id_ed25519
 Your public key has been saved in /Users/user.ssh/id_ed25519.pub
 The key fingerprint is:


### PR DESCRIPTION
I added the command line output when generating a new SSH key to the remotes intro chapter.
Fixes #272 