### PR TITLE
Add info on how to directly commit on GitLab

### DIFF
--- a/chapters/remotes-intro.qmd
+++ b/chapters/remotes-intro.qmd
@@ -928,7 +928,38 @@ As you make changes, GitHub automatically tracks your modifications in the edito
 
 ## {{< fa brands gitlab >}} GitLab
 
-Coming soon!
+You can add or edit files directly in GitLab. 
+This is particularly useful if you need to make quick changes without accessing your local repository.
+
+#### Adding a new file on GitLab {.unnumbered}
+
+1. Navigate to the relevant project on GitLab.
+1. Check if you are on the branch that you want to commit to. 
+If you want to commit on a new branch, you will be able to create one later on.
+1. Click on the "+" button and select "New file".
+1. Enter a name for your new file, including the appropriate file extension (for example, `example.txt`).
+1. Add your content in the text editor provided.
+1. Click on the "Commit changes" button in the upper right corner.
+1. Write a commit message describing the changes you are making.
+1. Choose if you want to commit to the branch you navigated to in step 2. 
+Alternatively, you can commit to a new branch and choose if you want to create a merge request.
+1. Create your merge request as usual, unless you are committing to main.
+In that case there is of course no merge request.
+
+#### Editing an existing file {.unnumbered}
+
+1. Navigate to the project and correct branch on GitLab and find the file you want to edit.
+1. Click on the file to view its contents.
+1. In the top-right corner of the file view, click on the pencil icon ("Edit") to start editing.
+1. Choose "Edit this file" and make the necessary changes to the file in the in-browser editor without moving to the Web IDE.
+You can add, modify, or delete content as needed.
+As you make changes, you can look at the differences to the original by switching to "Preview changes".
+1. Click on the "Commit changes" button in the upper right corner.
+1. Write a commit message describing the changes you are making.
+1. Choose if you want to commit to the branch you navigated to in step 1.
+Alternatively, you can commit to a new branch and choose if you want to create a merge request.
+1. Create your merge request as usual, unless you are committing to main.
+In that case there is of course no merge request.
 
 :::
 

--- a/chapters/remotes-intro.qmd
+++ b/chapters/remotes-intro.qmd
@@ -943,7 +943,7 @@ If you want to commit on a new branch, you will be able to create one later on.
 1. Write a commit message describing the changes you are making.
 1. Choose if you want to commit to the branch you navigated to in step 2. 
 Alternatively, you can commit to a new branch and choose if you want to create a merge request.
-1. Create your merge request as usual, unless you are committing to main.
+1. Create your merge request as usual, unless you are committing to the default branch (usually `main`).
 In that case there is of course no merge request.
 
 #### Editing an existing file {.unnumbered}
@@ -958,7 +958,7 @@ As you make changes, you can look at the differences to the original by switchin
 1. Write a commit message describing the changes you are making.
 1. Choose if you want to commit to the branch you navigated to in step 1.
 Alternatively, you can commit to a new branch and choose if you want to create a merge request.
-1. Create your merge request as usual, unless you are committing to main.
+1. Create your merge request as usual, unless you are committing to the default branch (usually `main`).
 In that case there is of course no merge request.
 
 :::


### PR DESCRIPTION
Added missing info how one can directly edit and commit files on GitLab in a calloutbox.
Had explanation for GitHub but was missing GitLab version.
Fixes #346 